### PR TITLE
fix: repo name changed from raw to args

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ _Symbols Outline_
 - [typescript.nvim](https://github.com/jose-elias-alvarez/typescript.nvim)
 - [flutter-tools.nvim](https://github.com/akinsho/flutter-tools.nvim)
 - [NeoClip](https://github.com/AckslD/nvim-neoclip.lua)
-- [Telescope live grep raw](nvim-telescope/telescope-live-grep-raw.nvim)
+- [Telescope live grep args](nvim-telescope/telescope-live-grep-args.nvim)
 - [fidget](https://github.com/j-hui/fidget.nvim)
 - [clangd_extensions.nvim](https://github.com/p00f/clangd_extensions.nvim)
 - [crates.nvim](https://github.com/Saecki/crates.nvim)

--- a/lua/user/keybindings.lua
+++ b/lua/user/keybindings.lua
@@ -314,7 +314,7 @@ M.config = function()
   }
   lvim.builtin.which_key.mappings.s.name = " Search"
   lvim.builtin.which_key.mappings["ss"] = {
-    "<cmd>lua require('telescope').extensions.live_grep_raw.live_grep_raw()<cr>",
+    "<cmd>lua require('telescope').extensions.live_grep_args.live_grep_args()<cr>",
     "String",
   }
   lvim.builtin.which_key.mappings["t"] = {

--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -436,7 +436,7 @@ M.config = function()
       disable = lvim.use_icons or not lvim.builtin.custom_web_devicons,
     },
     {
-      "nvim-telescope/telescope-live-grep-raw.nvim",
+      "nvim-telescope/telescope-live-grep-args.nvim",
     },
     { "mtdl9/vim-log-highlighting", ft = { "text", "log" } },
     {


### PR DESCRIPTION
when typing space s-s 
<img width="606" alt="Screenshot 2022-06-15 at 13 01 54" src="https://user-images.githubusercontent.com/7449/173815220-246b52e4-d049-4859-a2dd-d60176d33410.png">

follow the instructions https://github.com/nvim-telescope/telescope-live-grep-args.nvim/commit/77d53b25ef6eb080845b1dac8337cac0be6b9114
