### PR TITLE
fix: Use smart case by default instead of explicitly telling it to fi…

### DIFF
--- a/lua/user/builtin.lua
+++ b/lua/user/builtin.lua
@@ -523,7 +523,7 @@ M.config = function()
       }
       return true
     end,
-    find_command = { "fd", "--type=file", "--hidden", "--smart-case" },
+    find_command = { "fd", "--type=file", "--hidden" },
   }
   lvim.builtin.telescope.on_config_done = function(telescope)
     telescope.load_extension "file_create"


### PR DESCRIPTION
There is no --smart-case flag in fd so this results in telescope returning nothing when executing find_files functionality. Smart case is set by default so you don't need to set it in the find_command, this allows the functionality to work properly.