### PR TITLE
fix(vimtex): Don't use lazy.nvim's lazy loading

### DIFF
--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -277,6 +277,7 @@ M.config = function()
         vim.g.vimtex_view_enabled = true
       end,
       ft = "tex",
+      lazy = false,
     },
     {
       "nvim-neotest/neotest",


### PR DESCRIPTION
Vimtex advices users to not use lazy loading from the package manager. See the following issue: https://github.com/lervag/vimtex/issues/2601
![image](https://user-images.githubusercontent.com/48220549/212535437-90245e98-1700-45ee-825d-0812b084ba45.png)

