### PR TITLE
Fix hop lazy configuration. Remember does not work on BufWinEnter event

### DIFF
--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -65,7 +65,6 @@ M.config = function()
       config = function()
         require("remember").setup {}
       end,
-      event = "BufWinEnter",
       enabled = lvim.builtin.lastplace.active,
     },
     {
@@ -100,7 +99,7 @@ M.config = function()
     {
       "phaazon/hop.nvim",
       event = "VeryLazy",
-      commands = { "HopChar1CurrentLineAC", "HopChar1CurrentLineBC", "HopChar2MW", "HopWordMW" },
+      cmd = { "HopChar1CurrentLineAC", "HopChar1CurrentLineBC", "HopChar2MW", "HopWordMW" },
       config = function()
         require("user.hop").config()
       end,


### PR DESCRIPTION
* Fix `hop` to use the right lazy.nvim directive for commands.
* Remember does not work for me when using `BufWinEnter`.