### PR TITLE
fix input type for vim.list_extend

### DIFF
--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -51,7 +51,11 @@ if #extra_bundles == 0 then
         1
     )
 end
-vim.list_extend(bundles, extra_bundles)
+bundles = { bundles }
+vim.list_extend(
+  bundles,
+  { extra_bundles }
+)
 
 local config = {
   cmd = {


### PR DESCRIPTION
After copying java.lua and almost all all references to java or jdtls found in this project into my config, I got an error:

```
Error detected while processing BufReadPost Autocommands for "*":                                                                                               
Error executing lua callback: /usr/share/nvim/runtime/filetype.lua:22: Error executing lua: /usr/share/nvim/runtime/filetype.lua:23: Vim(runtime):E5113: Error w
hile calling lua chunk: ...rest/.local/share/lunarvim/lvim/lua/lvim/lsp/manager.lua:62: Vim:E5113: Error while calling lua chunk: vim/shared.lua:0: src: expecte
d table, got string                                                                                                                                             
stack traceback:                                                                                                                                                
        [C]: in function 'error'                                                                                                                                
        vim/shared.lua: in function 'validate'                                                                                                                  
        vim/shared.lua: in function 'list_extend'                                                                                                               
        /home/forrest/.config/lvim/ftplugin/java.lua:54: in main chunk                                                                                          
... 
```
This change allowed me to use the debugger for java.